### PR TITLE
Change representation of parsers, add some useful combinators

### DIFF
--- a/contrib/ParserCombinators.md
+++ b/contrib/ParserCombinators.md
@@ -123,21 +123,24 @@ A word that implements common behavior for all constructors.
 
 ### Encoding
 
-A parser in this library conceptionally (and currently also in reality) is a function, that takes a list as its input and returns a parse-result.
+A parser conceptionally is a function, that takes a list as its input and returns a parse-result.
+Currently a parser in this library is encoded as a quotation, that implements described behavior.
+
 Parsers created using this library are value-parsers.
 That is, that they can't just be used to parse strings, but also to accept and recognize patterns on arbitrary lists of values.
 
 ### Constant parsers, Using parsers
 
 ```consize
->> : parser-quotation ( quot -- parser ) get-dict func ;
+>> : parser-quotation ( quot -- parser ) ;
 >> 
 >> 
 ```
 The simplest possible parser (`parser-quotation`) is constructed from a quotation that implements the described behavior (accepting a list of values and returning a parse-result).
+Always use this constructor word to create a parser from a quotation, since the parsers' representation might change.
 
 ```consize
->> : parser-run ( parser input -- parse-result ) --stack swap apply unstack ;
+>> : parser-run ( parser input -- parse-result ) swap call ;
 >> 
 >> 
 ```

--- a/contrib/parsers-test.txt
+++ b/contrib/parsers-test.txt
@@ -56,6 +56,8 @@
 ( 3 ( 2 ) parse-result-success ) [ 2 parser-item 3 parser-item parser-append-right ( 2 3 2 ) parser-run ] unit-test
 ( { \ two 2 \ three 3 } ( ) parse-result-success ) [ 2 parser-item \ two parser-tag 3 parser-item \ three parser-tag parser-append-merge ( 2 3 ) parser-run ] unit-test
 ( { \ two 2 \ three 3 } ( 2 ) parse-result-success ) [ 2 parser-item \ two parser-tag 3 parser-item \ three parser-tag parser-append-merge ( 2 3 2 ) parser-run ] unit-test
+( 42 ( ) parse-result-success ) [ 42 \ ( \ ) [ parser-item ] tri@ parser-between ( \ ( 42 \ ) ) parser-run ] unit-test
+( 42 ( 3 ) parse-result-success ) [ 42 \ ( \ ) [ parser-item ] tri@ parser-between ( \ ( 42 \ ) \ 3 ) parser-run ] unit-test
 
 % disjunction of parsers
 ( 2 ( ) parse-result-success ) [ 2 parser-item 3 parser-item parser-or ( 2 ) parser-run ] unit-test
@@ -102,4 +104,27 @@
 ( ( ) ( ) parse-result-success ) [ 2 parser-item parser-opt ( ) parser-run ] unit-test
 ( ( 2 ) ( ) parse-result-success ) [ 2 parser-item parser-opt ( 2 ) parser-run ] unit-test
 ( ( 2 ) ( 7 ) parse-result-success ) [ 2 parser-item parser-opt ( 2 7 ) parser-run ] unit-test
+
+( 2 ( ) parse-result-success ) [ 2 parser-item \ + parser-item [ [ + ] ] parser-onsuccess parser-chainl1 ( 2 ) parser-run ] unit-test
+( 4 ( ) parse-result-success ) [ 2 parser-item \ + parser-item [ [ + ] ] parser-onsuccess parser-chainl1 \ 2+2 unword parser-run ] unit-test
+( 8 ( ) parse-result-success ) [ 2 parser-item \ + parser-item [ [ + ] ] parser-onsuccess parser-chainl1 \ 2+2+2+2 unword parser-run ] unit-test
+
+% lazy parsers
+
+: --parser-lazy-parser-test-exp ( -- parser ) --parser-lazy-parser-test-value \ + parser-item [ [ + ] ] parser-onsuccess parser-chainl1 ;
+: --parser-lazy-parser-test-value ( -- parser ) 1 parser-item [ --parser-lazy-parser-test-exp ] parser-lazy \ ( \ ) [ parser-item ] bi@ parser-between parser-or ;
+
+( 1 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp ( \ 1 ) parser-run ] unit-test
+( 2 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp \ 1+1 unword parser-run ] unit-test
+( 2 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1)+1 unword parser-run ] unit-test
+( 2 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp \ 1+(1) unword parser-run ] unit-test
+( 2 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1)+(1) unword parser-run ] unit-test
+( 4 ( ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1+1)+(1+1) unword parser-run ] unit-test
+
+( 1 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp ( \ 1 \ 3 ) parser-run ] unit-test
+( 2 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp \ 1+13 unword parser-run ] unit-test
+( 2 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1)+13 unword parser-run ] unit-test
+( 2 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp \ 1+(1)3 unword parser-run ] unit-test
+( 2 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1)+(1)3 unword parser-run ] unit-test
+( 4 ( 3 ) parse-result-success ) [ --parser-lazy-parser-test-exp \ (1+1)+(1+1)3 unword parser-run ] unit-test
 


### PR DESCRIPTION
# Change representation for parsers
Representing parsers as functions seemed a good idea at the time I implemented it, but it turned out to be a bad idea, since it caused a problem:
Because the construction of a function-value requires the enclosing context (dictionary), auxiliary words that are defined later are unknown in such a function value. In combination with the evaluation of list literals in words beeing defined this caused problems.

# Necessary and useful combinators
After using the parser-combinators for an advanced parser, I saw the need for some additional combinators. They're included in this PR.