### PR TITLE
Run Consize as container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM clojure
+COPY . /consize/
+WORKDIR /consize/src
+ENTRYPOINT ["clj", "-M", "consize.clj", "\\ prelude-plain.txt run say-hi"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "3"
+
+services:
+  consize-repl:
+    build: .

--- a/resources/DOCKER.md
+++ b/resources/DOCKER.md
@@ -1,0 +1,10 @@
+# HOW TO: RUN CONSIZE AS CONTAINER
+
+All commands are executed in this repositories root directory.
+
+## With docker-compose
+ * ```docker-compose up```
+
+## Without docker-compose
+ 1. ```docker build . -t consize```
+ 2. ```docker run -i consize```


### PR DESCRIPTION
Added Dockerfile to build consize from latest Clojure image.
docker-compose.yml to make handling the container easier for inexperienced Docker users.

DOCKER.md as short documentation on how to start the image.